### PR TITLE
fix: content security policy present in server

### DIFF
--- a/index.html
+++ b/index.html
@@ -55,6 +55,8 @@
   <!-- Prevent Search Engines from using a different description or archived version -->
   <meta name="robots" content="index,follow,noarchive,noodp,noydir">
 
+  <!-- Content Security Policy -->
+  <meta http-equiv="Content-Security-Policy" content="script-src 'nonce-dnNnM7qW30okGneLuaYNnw' 'strict-dynamic'; object-src 'none'; base-uri 'none';">
 
   <!-- Keywords - up to 10, 250 characters or less -->
   <meta name="keywords"


### PR DESCRIPTION
## Description

- On the website server, find that we add content security policy header ourselves
- So any change we want to do, we should do in the server.
- Checked website code and we do not have inline blocks, so we should be able to delete the unsafe-inline keyword without any issues

## Testing

For testing, added the following line on local, which did not show the Content-Security-Policy warnings. Removing the sites was done because we already have 'strict-dynamic'. But unsure if we should proceed with this change. Tested on firefox as on chrome getting following console log: Third-party cookie will be blocked in future Chrome versions as part of Privacy Sandbox.

## Links

Read the following MDN doc: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/script-src#unsafe_inline_script
Which says we should disallow inline scripts

## Screenshots

Original site
![image](https://github.com/user-attachments/assets/940f9a80-b796-45a1-9cd3-f30db035f420)

Updated locally
![image](https://github.com/user-attachments/assets/90d15c12-b50c-4a6b-881a-04daa9717f2c)

